### PR TITLE
Symmetrization of the tensor : first implementation with structure

### DIFF
--- a/abipy/core/tensor.py
+++ b/abipy/core/tensor.py
@@ -75,7 +75,7 @@ class Tensor(object):
         red_tensor = from_cart_to_red(cartesian_tensor,lattice)
         return cls(red_tensor, lattice,space)
 
-    def symmetrize(self):
+    def symmetrize(self,structure):
         tensor = self._reduced_tensor
 
         if self._is_real_space:
@@ -83,9 +83,7 @@ class Tensor(object):
         else:
             real_lattice = self._lattice.reciprocal_lattice
 
-        # Create a fake structure to get point group
-        real_structure = Structure(real_lattice,["H"],[[0,0,0]])
-        real_finder = SymmetryFinder(real_structure)
+        real_finder = SymmetryFinder(structure)
 
         real_symmops = real_finder.get_point_group_operations(cartesian=True)
 

--- a/abipy/electrons/bse.py
+++ b/abipy/electrons/bse.py
@@ -56,10 +56,10 @@ class DielectricTensor(object):
 
         return np.array(table)
 
-    def symmetrize(self):
+    def symmetrize(self,structure):
      
         for tensor in self._all_tensors:
-            tensor.symmetrize()
+            tensor.symmetrize(structure)
 
     def to_func1d(self,red_coords=True):
 


### PR DESCRIPTION
We could use a TensorSymmetrizer instead of passing the structure to symmetrize()
