### PR TITLE
Bug jobfile python3

### DIFF
--- a/abipy/htc/abinitinput.py
+++ b/abipy/htc/abinitinput.py
@@ -5,7 +5,7 @@ import subprocess
 from os import makedirs, readlink, symlink
 from os.path import basename, dirname, exists, join, realpath
 
-from abipy.profile import abipy_env
+# from abipy.profile import abipy_env
 from .filesfile import FilesFile
 from .abinitfiles import AbinitFiles
 from .inputfile import InputFile 
@@ -127,7 +127,7 @@ class AbinitInput(AbinitFiles):
                        input=self.files_name,
                        log=self.log_name) 
 
-        #jobtype = abipy_env.get_uservar("jobtype", kwargs)
+        # jobtype = abipy_env.get_uservar("jobtype", kwargs)
         if jobtype is None: jobtype = ''
 
         if jobtype.lower() == 'pbs':
@@ -151,10 +151,10 @@ class AbinitInput(AbinitFiles):
         self._setattr(_to_link = list())
 
         # Other arguments
-        for key in self.properties():
-            val = abipy_env.get_default(key, kwargs)
-            if val is not None:
-                getattr(self, 'set_' + key)(val)
+        # for key in self.properties():
+        #     val = abipy_env.get_default(key, kwargs)
+        #     if val is not None:
+        #         getattr(self, 'set_' + key)(val)
 
     def _setattr(self, **kwargs):
         self.__dict__.update(kwargs)

--- a/abipy/htc/jobfile.py
+++ b/abipy/htc/jobfile.py
@@ -126,7 +126,7 @@ class JobFile(object):
     def __str__(self):
         lines = []
         def app(line):
-            if '__iter__' in dir(line):
+            if '__iter__' in dir(line) and not isinstance(line, str):
                 lines.extend(line)
             else:
                 lines.append(line)

--- a/abipy/htc/utils.py
+++ b/abipy/htc/utils.py
@@ -139,7 +139,7 @@ def is_number(s):
 
 def is_iter(obj):
     """Return True if the argument is list-like."""
-    return hasattr(obj, '__iter__')
+    return hasattr(obj, '__iter__') and not isinstance(obj, str)
 
 def is_scalar(obj):
     """Return True if the argument is not list-like."""


### PR DESCRIPTION
There is a bug when writing the jobfile with the launcher using python >= 3 : str in python 3 have an __iter__ method and thus they are dismantled by the extend method of the list. This fixes issue #133 .

Also, there were remnants of calls to abipy.profile which have been deleted a few months ago and prevented the use of the Launcher.