### PR TITLE
fix target_dilatmx in relax workflow

### DIFF
--- a/abipy/flowtk/works.py
+++ b/abipy/flowtk/works.py
@@ -1058,7 +1058,7 @@ class RelaxWork(Work):
                 self.ioncell_task.reduce_dilatmx(target=self.target_dilatmx)
                 self.history.info('Converging dilatmx. Value reduce from {} to {}.'
                             .format(actual_dilatmx, self.ioncell_task.get_inpvar('dilatmx')))
-                self.ioncell_task.reset_from_scratch()
+                self.ioncell_task.restart()
 
         return super().on_ok(sender)
 

--- a/abipy/integration_tests/itest_relaxations.py
+++ b/abipy/integration_tests/itest_relaxations.py
@@ -248,4 +248,9 @@ def itest_relaxation_with_target_dilatmx(fwp, tvars):
 
     assert relax_work[1].input["dilatmx"] == 1.03
 
+    # check that when decreasing the dilatmx it actually takes the previously relaxed
+    # structure and does not start from scratch again: the lattice should not be the same.
+    assert not np.allclose(relax_work.ion_task.get_final_structure().lattice_vectors(),
+                           relax_work.ioncell_task.input.structure.lattice_vectors())
+
     flow.rmtree()


### PR DESCRIPTION
target_dilatmx was not updating the structure when restarting
