### PR TITLE
Quick fix for loading the package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE files
+.vscode
+
 # abipy files
 abinit_vars.pickle
 Profile.prof

--- a/abipy/core/structure.py
+++ b/abipy/core/structure.py
@@ -26,7 +26,7 @@ from abipy.flowtk import PseudoTable
 from abipy.core.mixins import NotebookWriter
 from abipy.core.symmetries import AbinitSpaceGroup
 from abipy.iotools import as_etsfreader, Visualizer
-from abipy.flowtk.abiobjects import structure_from_abivars, structure_to_abivars, species_by_znucl
+from abipy.flowtk.abiobjects import structure_from_abivars, structure_to_abivars
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

The following line failed due to a missing object in the import:
```python
from abipy import abilab, flowtk
```