### PR TITLE
Hotfix : @Structure Dependency

### DIFF
--- a/abipy/flowtk/nodes.py
+++ b/abipy/flowtk/nodes.py
@@ -135,11 +135,7 @@ class Dependency(object):
         if exts and is_string(exts): exts = exts.split()
 
         # Extract extensions.
-        self.exts = [e for e in exts if not e.startswith("@")]
-
-        # Save getters
-        self.getters = [e for e in exts if e.startswith("@")]
-        #if self.getters: print(self.getters)
+        self.exts = [e for e in exts]
 
     def __hash__(self):
         return hash(self._node)
@@ -174,9 +170,16 @@ class Dependency(object):
 
         return _products
 
+    def get_getters(self):
+        """
+        Return the list of getters.
+        Getters are special ext starting with @.
+        """
+        return [e for e in self.exts if e.startswith("@")]
+
     def apply_getters(self, task):
         """
-        This function is called when we specify the task dependencies with the syntax:
+        This function apply particular exts with the syntax:
 
             deps={node: "@property"}
 
@@ -186,9 +189,8 @@ class Dependency(object):
 
             - @structure
         """
-        if not self.getters: return
-
-        for getter in self.getters:
+        getters = self.get_getters()
+        for getter in getters:
             if getter == "@structure":
                 task.history.info("Getting structure from %s" % self.node)
                 new_structure = self.node.get_final_structure()
@@ -226,7 +228,7 @@ class Product(object):
             ext: ABINIT file extension
             path: (asbolute) filepath
         """
-        if ext not in abi_extensions():
+        if ext not in abi_extensions() and not ext.startswith("@"):
             raise ValueError("Extension `%s` has not been registered in the internal database" % str(ext))
 
         self.ext = ext

--- a/abipy/flowtk/tasks.py
+++ b/abipy/flowtk/tasks.py
@@ -2189,7 +2189,6 @@ class Task(Node, metaclass=abc.ABCMeta):
         such as the creation of the symbolic links needed to connect different tasks.
         """
         for d in self.deps:
-            print("d.exts: ", d.exts)
             if [e for e in d.exts if not e.startswith("@")]: #Here we work on normal deps
                 self.make_links()
                 cvars = d.connecting_vars()


### PR DESCRIPTION
Hotfix : Using @structure with Dependency written as a dict

Context :
A Dependency between 2 tasks is written as a Dependency containing Node and ext where ext is the format of the file. When the structure depends on a previous task, we need to use a getters (@structure) which is another property of Dependency really similar to exts.
In the code, we always use a Dependency List and when given a Dependency Dict, we just transform it right back as a List. When doing this, we only takes into account exts and not getters. 

Problem : 

- In a simple task with these 2 lines, the structure from the second task won't depend on the final structure of the first task.
  ```
  new_work.register_relax_task(ion_inp)
  new_work.register_relax_task(ioncell_inp, deps={new_work[0]: "@structure"})
  ```
- Graphviz won't be able to show Dependency between those task.
- The __str__ of Dependency doesn't show the dependency on @structure.  

Solution :
From what I understand from the code, the only reason we want getters is for the function `apply_getters(self, task)` of |Task|. To fix the issue and to maintain the code, I've deleted getters properties and @structure is now an ext. The function apply_getters look at ext starting with @. To make this solution elegant, instead of treating dependencies in task.start() and task._setup(), I only treat them in task._setup() 

Notes : 
I choose this solution because it fix problems with __str__ of Dependency, graphviz and probably at other places. A better solution would be to make exts and getters inherit from a class.