### PR TITLE
automatic input generation without files file

### DIFF
--- a/abipy/abio/tests/test_abivars.py
+++ b/abipy/abio/tests/test_abivars.py
@@ -7,6 +7,7 @@ from pymatgen.core.units import bohr_to_ang
 from abipy.core.structure import *
 from abipy.core.testing import AbipyTest
 from abipy.abio.abivars import AbinitInputFile, AbinitInputParser, expand_star_syntax, structure_from_abistruct_fmt
+from abipy.abio.abivars import format_string_abivars
 
 
 class TestAbinitInputParser(AbipyTest):
@@ -313,3 +314,9 @@ xred_symbols
         from abipy.core.structure import Structure
         same_mgb2 = Structure.from_abistring(string)
         assert same_mgb2 == mgb2
+
+    def test_format_string_abivars(self):
+        assert format_string_abivars("ecut", 30) == 30
+        assert format_string_abivars("pseudos", ["xxx", "yyy"]) == '\n    "xxx,\n    yyy"'
+        assert format_string_abivars("pseudos", 'xxx') == '"xxx"'
+        assert format_string_abivars("pseudos", '"xxx"') == '"xxx"'

--- a/abipy/abio/tests/test_inputs.py
+++ b/abipy/abio/tests/test_inputs.py
@@ -78,6 +78,8 @@ class TestAbinitInput(AbipyTest):
         assert inp.to_string(sortmode=None, with_structure=True, with_pseudos=True)
         assert inp.to_string(sortmode=None, with_structure=True, with_pseudos=False, mode="html")
         assert inp.to_string(sortmode="a", with_structure=False, with_pseudos=False, mode="html")
+        assert inp.to_string(sortmode=None, with_structure=True, with_pseudos=True, files_file=False)
+        assert inp.to_string(sortmode="section", with_structure=True, with_pseudos=True, files_file=False)
         assert inp._repr_html_()
 
         inp.set_vars(ecut=5, toldfe=1e-6, comment="hello")
@@ -93,6 +95,10 @@ class TestAbinitInput(AbipyTest):
         # Cannot change structure variables directly.
         with self.assertRaises(inp.Error):
             inp.set_vars(unit_cell)
+
+        # Cannot change pseudos variables directly.
+        with self.assertRaises(inp.Error):
+            inp.set_vars(pseudos=["Si.psp"])
 
         with self.assertRaises(TypeError):
             inp.add_abiobjects({})
@@ -159,6 +165,9 @@ class TestAbinitInput(AbipyTest):
         assert new_inp["nshiftk"] == 3
         other_inp = new_inp.new_with_vars(ph_qpath=[0, 0, 0, 0.5, 0, 0])
         assert other_inp["ph_nqpath"] == 2
+
+        new_inp["outdata_prefix"] = "some/path"
+        assert "some/path" in new_inp.to_string()
 
     def test_input_errors(self):
         """Testing typical AbinitInput Error"""
@@ -244,6 +253,8 @@ class TestAbinitInput(AbipyTest):
 
         inp["kptopt"] = 4
         assert not inp.uses_ktimereversal
+
+        assert inp.pseudos_abivars["pseudos"] == f'"{pseudo.filepath}"'
 
     def test_new_with_structure(self):
         """Testing new_with_structure."""
@@ -860,6 +871,7 @@ class AnaddbInputTest(AbipyTest):
         inp = AnaddbInput(self.structure, comment="hello anaddb", anaddb_kwargs={"brav": 1})
         repr(inp); str(inp)
         assert inp.to_string(sortmode="a")
+        assert inp.to_string(sortmode=None, files_file=False)
         assert inp._repr_html_()
         assert "brav" in inp
         assert inp["brav"] == 1

--- a/abipy/dfpt/gruneisen.py
+++ b/abipy/dfpt/gruneisen.py
@@ -730,7 +730,7 @@ class GrunsNcFile(AbinitNcFile, Has_Structure, NotebookWriter):
             q1shft=(0, 0, 0), qptbounds=qptbounds, asr=asr, chneut=chneut, dipdip=dipdip, dos_method=dos_method,
             lo_to_splitting=lo_to_splitting, anaddb_kwargs=anaddb_kwargs)
 
-        inp["gruns_ddbs"] = ['"'+p+'"\n' for p in ddb_list]
+        inp["gruns_ddbs"] = ddb_list
         inp["gruns_nddbs"] = len(ddb_list)
 
         task = AnaddbTask.temp_shell_task(inp, ddb_node=ddb0.filepath, workdir=workdir, manager=manager, mpi_procs=mpi_procs)

--- a/abipy/dfpt/tests/test_converters.py
+++ b/abipy/dfpt/tests/test_converters.py
@@ -162,6 +162,8 @@ class ConverterTest(AbipyTest):
         self.assertArrayAlmostEqual(ananc.epsinf, conv_nac["dielectric"], decimal=5)
 
     def test_tdep_lotosplitting(self):
+        self.skip_if_not_phonopy()
+
         tmp_dir = tempfile.mkdtemp()
         primitive = get_phonopy_structure(abilab.Structure.from_file(os.path.join(test_dir, "MgO_phonopy_POSCAR")))
         born_path = parse_BORN(primitive, filename=os.path.join(test_dir, "MgO_phonopy_BORN"))
@@ -170,6 +172,8 @@ class ConverterTest(AbipyTest):
         self.assertTrue(os.path.isfile(loto_path))
 
     def test_tdep_ddb(self):
+        self.skip_if_not_phonopy()
+
         tmp_dir = tempfile.mkdtemp()
         out_ddb_path = os.path.join(tmp_dir, "out_DDB")
 


### PR DESCRIPTION
## Summary

Introduce automatic addition of data_prefix and pseudos to the string representation of the abinit input files. First step in the removal of the the files file from the workflow.   
The presence of these additional elements is controlled by a `files_file` option for `write` and `to_string`. The default is currently `True` preserving the old behavior while workflows depending on this are adapted to the new interface. 
