### PR TITLE
Fix SlotPickleMixin import error

### DIFF
--- a/abipy/core/kpoints.py
+++ b/abipy/core/kpoints.py
@@ -13,10 +13,11 @@ from monty.collections import AttrDict, dict2namedtuple
 from monty.functools import lazy_property
 from monty.string import marquee
 from pymatgen.core.lattice import Lattice
-from pymatgen.util.serialization import pmg_serialize, SlotPickleMixin
+from pymatgen.util.serialization import pmg_serialize
 from abipy.iotools import ETSF_Reader
 from abipy.tools.derivatives import finite_diff
 from abipy.tools.numtools import add_periodic_replicas, is_diagonal
+from abipy.core.mixins import SlotPickleMixin
 
 import logging
 logger = logging.getLogger(__name__)

--- a/abipy/core/mixins.py
+++ b/abipy/core/mixins.py
@@ -25,6 +25,7 @@ __all__ = [
     "Has_PhononBands",
     "NotebookWriter",
     "Has_Header",
+    "SlotPickleMixin"
 ]
 
 
@@ -949,3 +950,17 @@ class Has_Header(object):
         return self.reader.read_abinit_hdr()
 
     #def compare_hdr(self, other_hdr):
+
+
+class SlotPickleMixin:
+    """
+    This mixin makes it possible to pickle/unpickle objects with __slots__
+    defined.
+    """
+
+    def __getstate__(self):
+        return {slot: getattr(self, slot) for slot in self.__slots__ if hasattr(self, slot)}
+
+    def __setstate__(self, state):
+        for slot, value in state.items():
+            setattr(self, slot, value)

--- a/abipy/core/symmetries.py
+++ b/abipy/core/symmetries.py
@@ -13,8 +13,8 @@ from monty.functools import lazy_property
 from monty.termcolor import cprint
 from monty.collections import dict2namedtuple
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from pymatgen.util.serialization import SlotPickleMixin
 from abipy.core.kpoints import wrap_to_ws, issamek, has_timrev_from_kptopt
+from abipy.core.mixins import SlotPickleMixin
 
 
 __all__ = [


### PR DESCRIPTION
There seems to be an import error due to changes in the pymatgen.util.serialization, where the SlotPickleMixin is now removed from the package. This will patch the error.
