### PR TITLE
add option to convert from phonopy yaml file to ddb

### DIFF
--- a/abipy/dfpt/converters.py
+++ b/abipy/dfpt/converters.py
@@ -18,7 +18,7 @@ from abipy.abio.factories import minimal_scf_input
 from abipy.electrons.gsr import GsrFile
 from monty.os import makedirs_p
 try:
-    from phonopy import Phonopy
+    from phonopy import Phonopy, load
     from phonopy.file_IO import write_FORCE_CONSTANTS, parse_FORCE_CONSTANTS, parse_BORN, parse_FORCE_SETS
     #from phonopy.interface.phonopy_yaml import PhonopyYaml
     from phonopy.interface.calculator import get_default_physical_units, get_force_constant_conversion_factor
@@ -169,14 +169,16 @@ def abinit_to_phonopy(anaddbnc, supercell_matrix, symmetrize_tensors=False, outp
 
 
 @requires(Phonopy, "phonopy not installed!")
-def phonopy_to_abinit(unit_cell, supercell_matrix, out_ddb_path, ngqpt=None, qpt_list=None,
-                      force_constants=None, force_sets=None, born=None,
+def phonopy_to_abinit(unit_cell=None, supercell_matrix=None, out_ddb_path=None, ngqpt=None, qpt_list=None,
+                      force_constants=None, force_sets=None, phonopy_yaml=None,  born=None,
                       primitive_matrix="auto", symprec=1e-5, tolsym=None, supercell=None,
                       calculator=None, manager=None, workdir=None, pseudos=None, verbose=False):
     """
     Converts the data from phonopy to an abinit DDB file. The data can be provided
     in form of arrays or paths to the phonopy files that should be parsed.
-    The minimal input should contains the FORCE_CONSTANTS or FORCE_SETS.
+    The minimal input should contains the FORCE_CONSTANTS or FORCE_SETS,
+    or the phonopy.yaml ouput from the postprocessing of phonopy
+    (https://phonopy.github.io/phonopy/output-files.html#phonopy-yaml-and-phonopy-disp-yaml).
     If BORN is present the Born effective charges (BEC) and dielectric
     tensor will also be added to the DDB.
 
@@ -194,7 +196,7 @@ def phonopy_to_abinit(unit_cell, supercell_matrix, out_ddb_path, ngqpt=None, qpt
 
     Args:
         unit_cell: a |Structure| object that identifies the unit cell used for the phonopy
-            calculation.
+            calculation. 
         supercell_matrix: a 3x3 array representing the supercell matrix used to generated the
             forces with phonopy.
         out_ddb_path: a full path to the file where the new DDB will be written
@@ -203,11 +205,15 @@ def phonopy_to_abinit(unit_cell, supercell_matrix, out_ddb_path, ngqpt=None, qpt
             At least one among ngqpt and qpt_list should be defined.
         force_constants: an array with shape (num atoms unit cell, num atoms supercell, 3, 3)
             containing the force constants. Alternatively a string with the path to the
-            FORCE_CONSTANTS file. This or force_set should be defined. If both given this
+            FORCE_CONSTANTS file. This or force_set or phonopy_yaml should be defined. If both given this
             has precedence.
         force_sets: a dictionary obtained from the force sets generated with phonopy.
             Alternatively a string with the path to the FORCE_SETS file. This or force_constants
-            should be defined.
+            or phonopy_yaml should be defined.
+        phonopy_yaml: a filename from the post-processing of phonopy (phonopy.yaml),
+            see https://phonopy.github.io/phonopy/output-files.html#phonopy-yaml-and-phonopy-disp-yaml
+            This or force_constants or force_sets should be dependent. Note that the unit_cel,
+            supercell_matrix, primitive_matrix are included in this file so they do not need to be given.
         born: a dictionary with "dielectric" and "born" keywords as obtained from the nac_params
             in phonopy. Alternatively a string with the path to the BORN file. Notice that
             the "factor" attribute is not taken into account, so the values should be in
@@ -236,13 +242,16 @@ def phonopy_to_abinit(unit_cell, supercell_matrix, out_ddb_path, ngqpt=None, qpt
         a DdbFile instance of the file written in out_ddb_path.
     """
 
+
     if ngqpt is None and qpt_list is None:
         raise ValueError("at least one among nqgpt and qpt_list should be defined")
 
-    if force_sets is None and force_constants is None:
+    if not ((force_sets is not None) or  (force_constants is not None) or (phonopy_yaml is not None) ):
         raise ValueError("at least one of force_sets and force_constants should be provided")
 
-    phon_at = get_phonopy_structure(unit_cell)
+
+    if unit_cell is not None:
+        phon_at = get_phonopy_structure(unit_cell)
 
     if isinstance(force_constants, str):
         force_constants = parse_FORCE_CONSTANTS(filename=force_constants)
@@ -253,9 +262,22 @@ def phonopy_to_abinit(unit_cell, supercell_matrix, out_ddb_path, ngqpt=None, qpt
     if isinstance(force_sets, str):
         force_sets = parse_FORCE_SETS(filename=force_sets)
 
-    # no nac_params here, otherwise they will be used for the interpolation
-    phonon = Phonopy(phon_at, supercell_matrix, primitive_matrix=primitive_matrix, nac_params=None,
-                     symprec=symprec, calculator=calculator)
+
+    if phonopy_yaml is not None:
+        phonon=load(phonopy_yaml=phonopy_yaml,
+                    supercell_matrix=supercell_matrix,
+                    primitive_matrix=primitive_matrix,
+                    unitcell=unit_cell,
+                    symprec=symprec,
+                    is_nac=False,
+                    nac_params=None,
+                    calculator=calculator
+
+                    )
+    else:
+        # no nac_params here, otherwise they will be used for the interpolation
+        phonon = Phonopy(phon_at, supercell_matrix, primitive_matrix=primitive_matrix, nac_params=None,
+                         symprec=symprec, calculator=calculator)
 
     primitive = get_pmg_structure(phonon.primitive)
 
@@ -286,9 +308,11 @@ def phonopy_to_abinit(unit_cell, supercell_matrix, out_ddb_path, ngqpt=None, qpt
 
     if force_constants is not None:
         phonon.force_constants = force_constants
-    else:
+    elif force_sets is not None:
         phonon.dataset = force_sets
         phonon.produce_force_constants()
+    else: # phonopy_yaml already included the forceconstants
+        pass
 
     if calculator:
         units = get_default_physical_units(calculator)


### PR DESCRIPTION
Phonopy can store the unitcell/supercell/forceconstants/etc into a yaml file.
https://phonopy.github.io/phonopy/output-files.html#phonopy-yaml-and-phonopy-disp-yaml
Add the option to convert this file into ddb. 