### PR TITLE
Replace `monty.os.path.which` with `shutil.which`

### DIFF
--- a/abipy/gui/awx/dialogs.py
+++ b/abipy/gui/awx/dialogs.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 import os
 import wx
 
-from monty.os.path import which
+from shutil import which
 from monty.string import is_string
 
 


### PR DESCRIPTION
## Summary

The `which` function of the `monty.os.path.which` module was deprecated some time ago. Here we replace it with the `shutil.which` function, which has been added since Python v3.3