### PR TITLE
Fix `AbinitTimerParseError` import

### DIFF
--- a/abipy/flowtk/abitimer.py
+++ b/abipy/flowtk/abitimer.py
@@ -1,3 +1,9 @@
 # flake8: noqa
-#from pymatgen.io.abinit.abitimer import AbinitTimerParserError, AbinitTimerParser, AbinitTimerSection
-from pymatgen.io.abinit.abitimer import AbinitTimerParseError, AbinitTimerParser, AbinitTimerSection
+from pymatgen.core import __version__ as pmg_version
+from pymatgen.io.abinit.abitimer import AbinitTimerParser, AbinitTimerSection
+
+
+if pmg_version < '2023.7.10':
+    from pymatgen.io.abinit.abitimer import AbinitTimerParserError as AbinitTimerParseError
+else:
+    from pymatgen.io.abinit.abitimer import AbinitTimerParseError


### PR DESCRIPTION
Fixes #262 

In the following breaking change in `pymatgen`:

https://github.com/materialsproject/pymatgen/commit/5b88fc181d8ab97a7d1d3c47692cefdf673888c5

The `AbinitTimerParserError` class was renamed to `AbinitTimerParseError`. Although the code has already been updated for this change, in some environments installing `pymatgen>=2023.7.11` will lead to dependency conflicts. Here we adapt the import to be dependent on the installed version of `pymatgen` at runtime.
