### PR TITLE
Backwards compatibility for deprecated pymatgen.core.units.Memory.from_string

### DIFF
--- a/abipy/flowtk/flows.py
+++ b/abipy/flowtk/flows.py
@@ -2498,7 +2498,11 @@ Use the `abirun.py FLOWDIR history` command to print the log files of the differ
         def any2bytes(s):
             """Convert string or number to memory in bytes."""
             if is_string(s):
-                return int(Memory.from_string(s).to("b"))
+                # Support for deprecated pymatgen API
+                try:
+                    mem = int(Memory.from_string(s).to("b"))
+                except:
+                    mem = int(Memory.from_str(s).to("b"))
             else:
                 return int(s)
 

--- a/abipy/flowtk/qadapters.py
+++ b/abipy/flowtk/qadapters.py
@@ -215,7 +215,12 @@ class Hardware:
 
         # Convert memory to megabytes.
         m = str(kwargs.pop("mem_per_node"))
-        self.mem_per_node = int(Memory.from_string(m).to("Mb"))
+
+        # Support for old pymatgen API
+        try:
+            self.mem_per_node = int(Memory.from_string(m).to("Mb"))
+        except:
+            self.mem_per_node = int(Memory.from_str(m).to("Mb"))
 
         if self.mem_per_node <= 0 or self.sockets_per_node <= 0 or self.cores_per_socket <= 0:
             raise ValueError("invalid parameters: %s" % kwargs)


### PR DESCRIPTION
## Summary

* Added a `try`/`except`  block for the two places this breaks abipy, [related pymatgen commit](https://github.com/materialsproject/pymatgen/commit/7da8d0a0b80e7ef0a554b506c78880de756f5e1d)