### PR TITLE
Import optimisation

### DIFF
--- a/abipy/dynamics/hist.py
+++ b/abipy/dynamics/hist.py
@@ -14,7 +14,6 @@ from monty.collections import AttrDict
 from monty.string import marquee, list_strings
 from pymatgen.core.periodic_table import Element
 from pymatgen.analysis.structure_analyzer import RelaxationAnalyzer
-from pymatgen.io.vasp.outputs import Xdatcar
 from abipy.tools.plotting import add_fig_kwargs, get_ax_fig_plt, get_axarray_fig_plt, set_visible, get_figs_plotly, \
     get_fig_plotly, add_plotly_fig_kwargs, plotlyfigs_to_browser, push_to_chart_studio, PlotlyRowColDesc, plotly_set_lims, \
     latex_greek_2unicode
@@ -180,6 +179,8 @@ class HistFile(AbinitNcFile, NotebookWriter):
             to_unit_cell (bool): Whether to translate sites into the unit cell.
             kwargs: keywords arguments passed to Xdatcar constructor.
         """
+        from pymatgen.io.vasp.outputs import Xdatcar
+
         filepath = self.write_xdatcar(filepath=filepath, groupby_type=groupby_type,
                                       to_unit_cell=to_unit_cell, overwrite=True)
 
@@ -201,6 +202,8 @@ class HistFile(AbinitNcFile, NotebookWriter):
         Return:
             path to Xdatcar file.
         """
+        from pymatgen.io.vasp.outputs import Xdatcar
+
         if filepath is not None and os.path.exists(filepath) and not overwrite:
             raise RuntimeError("Cannot overwrite pre-existing file `%s`" % filepath)
 

--- a/abipy/dynamics/hist.py
+++ b/abipy/dynamics/hist.py
@@ -202,6 +202,7 @@ class HistFile(AbinitNcFile, NotebookWriter):
         Return:
             path to Xdatcar file.
         """
+        # This library takes 13s to import on HPC (07/02/24) so moved to class method instead of header
         from pymatgen.io.vasp.outputs import Xdatcar
 
         if filepath is not None and os.path.exists(filepath) and not overwrite:

--- a/abipy/electrons/lobster.py
+++ b/abipy/electrons/lobster.py
@@ -15,8 +15,6 @@ from monty.termcolor import cprint
 from monty.functools import lazy_property
 from pymatgen.core.periodic_table import Element
 from pymatgen.electronic_structure.core import OrbitalType
-from pymatgen.io.vasp.outputs import Vasprun
-from pymatgen.io.vasp.inputs import Potcar
 from pymatgen.io.abinit.pseudos import Pseudo
 from abipy.core.func1d import Function1D
 from abipy.core.mixins import BaseFile, NotebookWriter
@@ -1166,6 +1164,10 @@ class LobsterInput(object):
         Returns:
             A LobsterInput.
         """
+        # These two libraries take a long time to import on HPC (07/02/24) so moved to method instead of header
+        from pymatgen.io.vasp.outputs import Vasprun
+        from pymatgen.io.vasp.inputs import Potcar
+
         # Try to determine the code used for the calculation
         dft_code = None
         if os.path.isfile(os.path.join(dirpath, 'vasprun.xml')):


### PR DESCRIPTION
## Summary

On the CECI HPC abilab can take 34s to import with and without pre-compiled wheels, affecting performance of downstream high throughput studies.

After profiling this comes from the `abipy.dynamics.hist` and `abipy.electrons.lobster` header imports, specifically the `pymatgen.io.vasp.outputs.Vasprun`, `pymatgen.io.vasp.inputs.Potcar`, and `pymatgen.io.vasp.outputs.Xdatcar`. These pymatgen classes are exclusively used in read/write abipy class methods, so the import has been moved to the start of each method as a workaround.

Abilab now imports in about a second on my CECI environment
