### PR TITLE
Replace pkg_resources with packaging

### DIFF
--- a/abipy/abilab.py
+++ b/abipy/abilab.py
@@ -423,7 +423,7 @@ def abicheck(verbose: int = 0) -> str:
         Compare two version strings with the given operator ``op``
         >>> assert cmp_version("1.1.1", "1.1.0") and not cmp_version("1.1.1", "1.1.0", op="==")
         """
-        from pkg_resources import parse_version
+        from packaging.version import parse as parse_version
         from monty.operator import operator_from_str
         op = operator_from_str(op)
         return op(parse_version(this), parse_version(other))

--- a/abipy/core/kpoints.py
+++ b/abipy/core/kpoints.py
@@ -1400,6 +1400,8 @@ class Kpath(KpointList):
             for line in self.lines:
                 vals_on_line = eigens[spin, line, band]
         """
+        if len(self) < 2:
+            return tuple()
         prev = self.versors[0]
         lines = [[0]]
 

--- a/abipy/core/testing.py
+++ b/abipy/core/testing.py
@@ -39,7 +39,7 @@ def cmp_version(this: str, other: str, op: str = ">=") -> bool:
     Compare two version strings with the given operator ``op``
     >>> assert cmp_version("1.1.1", "1.1.0") and not cmp_version("1.1.1", "1.1.0", op="==")
     """
-    from pkg_resources import parse_version
+    from packaging.version import parse as parse_version
     from monty.operator import operator_from_str
     op = operator_from_str(op)
     return op(parse_version(this), parse_version(other))

--- a/abipy/flowtk/tasks.py
+++ b/abipy/flowtk/tasks.py
@@ -1263,7 +1263,7 @@ class AbinitBuild:
 
     def compare_version(self, version_string, op):
         """Compare Abinit version to `version_string` with operator `op`"""
-        from pkg_resources import parse_version
+        from packaging.version import parse as parse_version
         from monty.operator import operator_from_str
         op = operator_from_str(op)
         return op(parse_version(self.version), parse_version(version_string))

--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,7 @@ def cleanup():
 
 install_requires = [
     "monty",
+    "packaging",
     "tabulate",
     "apscheduler<=3.10.4",
     "pydispatcher>=2.0.5",


### PR DESCRIPTION
## Summary

pkg_resources is deprecated, and was used in abipy for the function parse_version.
Replace this function with packaging.version.parse.