### PR TITLE
Fix dead link and add resource to docs/workflows/taskmanager.rst

### DIFF
--- a/docs/links.rst
+++ b/docs/links.rst
@@ -55,7 +55,7 @@
 .. _slurm: https://slurm.schedmd.com/
 .. _pbspro: http://pbspro.org/
 .. _sge: http://gridscheduler.sourceforge.net/howto/GridEngineHowto.html
-.. _torque: http://www.adaptivecomputing.com/products/open-source/torque/
+.. _torque: https://github.com/adaptivecomputing/torque
 .. _moab: http://www.adaptivecomputing.com/products/hpc-products/moab-hpc-basic-edition/
 .. _loadleveler: https://www.ibm.com/support/knowledgecenter/en/SSFJTW
 

--- a/docs/workflows/taskmanager.rst
+++ b/docs/workflows/taskmanager.rst
@@ -43,7 +43,8 @@ AbiPy obtains the information needed to create the correct ``TaskManager`` for a
 from the ``manager.yml`` configuration file.
 The file is written in YAML_ a human-readable data serialization language commonly used for configuration files
 (a good introduction to the YAML syntax can be found `here <http://yaml.org/spec/1.1/#id857168>`_.
-See also this `reference card <http://www.yaml.org/refcard.html>`_)
+See also this `reference card <http://www.yaml.org/refcard.html>`_. Experiment with YAML syntax using a
+`YAML validator <https://yamline.com/validator/>`_)
 
 By default, AbiPy looks for a ``manager.yml`` file in the current working directory i.e.
 the directory in which you execute your script in first and then inside ``$HOME/.abinit/abipy``.

--- a/docs/workflows/taskmanager.rst
+++ b/docs/workflows/taskmanager.rst
@@ -43,8 +43,8 @@ AbiPy obtains the information needed to create the correct ``TaskManager`` for a
 from the ``manager.yml`` configuration file.
 The file is written in YAML_ a human-readable data serialization language commonly used for configuration files
 (a good introduction to the YAML syntax can be found `here <http://yaml.org/spec/1.1/#id857168>`_.
-See also this `reference card <http://www.yaml.org/refcard.html>`_. Experiment with YAML syntax using a
-`YAML validator <https://yamline.com/validator/>`_)
+See also this `reference card <http://www.yaml.org/refcard.html>`_.
+Experiment with YAML syntax using a `YAML validator <https://yamline.com/validator/>`_)
 
 By default, AbiPy looks for a ``manager.yml`` file in the current working directory i.e.
 the directory in which you execute your script in first and then inside ``$HOME/.abinit/abipy``.


### PR DESCRIPTION
## Summary

Replace dead link http://www.adaptivecomputing.com/products/open-source/torque/ with https://github.com/adaptivecomputing/torque.
Add a YAML resource to check the configuration file syntax.
