### PR TITLE
More digits for ABINIT paths with abistruct.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -468,3 +468,5 @@ AbiPy is released under the GNU GPL license. For more details see the LICENSE fi
 .. |docs-github| image:: https://img.shields.io/badge/docs-ff69b4.svg
      :alt: AbiPy Documentation
      :target: http://abinit.github.io/abipy
+
+# One line at the end

--- a/README.rst
+++ b/README.rst
@@ -468,4 +468,3 @@ AbiPy is released under the GNU GPL license. For more details see the LICENSE fi
 .. |docs-github| image:: https://img.shields.io/badge/docs-ff69b4.svg
      :alt: AbiPy Documentation
      :target: http://abinit.github.io/abipy
-

--- a/README.rst
+++ b/README.rst
@@ -469,4 +469,3 @@ AbiPy is released under the GNU GPL license. For more details see the LICENSE fi
      :alt: AbiPy Documentation
      :target: http://abinit.github.io/abipy
 
-# One line at the end

--- a/abipy/core/structure.py
+++ b/abipy/core/structure.py
@@ -2351,7 +2351,7 @@ class Structure(pmg_Structure, NotebookWriter):
             app(" kptopt %d" % -(len(self.hsym_kpoints) - 1))
             app(" kptbounds")
             for k in self.hsym_kpoints:
-                app("    {:+.5f}  {:+.5f}  {:+.5f}  # {kname}".format(*k.frac_coords, kname=k.name))
+                app("    {:+.9f}  {:+.9f}  {:+.9f}  # {kname}".format(*k.frac_coords, kname=k.name))
 
         elif fmt in ("wannier90", "w90"):
             app("# Wannier90 structure")


### PR DESCRIPTION
The number of digits for k-points printed with `abistruct.py kpath` was so low that some high-symmetry points went undetected with ` gsr.ebands.plot()`. The number of digits has been increased from 5 to 9. No modifications were made for the SIESTA output because performance for Siesta has not been tested.

See before (unconverged):

![before](https://github.com/user-attachments/assets/3fa79e44-c240-4f30-bed0-420c18e67f8a)

And after:

![after](https://github.com/user-attachments/assets/d4b7c2a6-19cb-49fb-a442-9d3451fa74c6)




