### PR TITLE
Fix indexing in GwrRobot for ax_mat access

### DIFF
--- a/abipy/electrons/gwr.py
+++ b/abipy/electrons/gwr.py
@@ -1863,7 +1863,7 @@ class GwrRobot(Robot, RobotWithEbands):
 
         for spin in range(nsppol):
             for ix, (sigma_kpt, ikcalc) in enumerate(qpkinds):
-                ax = ax_mat[ikcalc, spin]
+                ax = ax_mat[ix, spin]
                 data = self.get_dirgaps_dataframe(kpoint=ikcalc,
                                                   spin=spin,
                                                   with_params=True,


### PR DESCRIPTION
Correct the indexing in the GwrRobot class to properly access the ax_mat array in the get_dirgaps_dataframe method.