### PR TITLE
Allow `exist_ok` in makedirs

### DIFF
--- a/abipy/flowtk/qadapters.py
+++ b/abipy/flowtk/qadapters.py
@@ -286,7 +286,8 @@ class _ExcludeNodesFile:
 
     def __init__(self):
         if not os.path.exists(self.FILEPATH):
-            if not os.path.exists(self.DIRPATH): os.makedirs(self.DIRPATH)
+            if not os.path.exists(self.DIRPATH):
+                os.makedirs(self.DIRPATH,exist_ok=True)
             with FileLock(self.FILEPATH):
                 with open(self.FILEPATH, "w") as fh:
                     json.dump({}, fh)


### PR DESCRIPTION
This came up in the CI runners for `atomate2`, which uses abipy. Since we use `pytest-xdist` to do parallel testing, a few runners would try to make the same `~/.abinit` directory, [causing them to fail](https://github.com/materialsproject/atomate2/actions/runs/18511550813/job/52753409924). This just allows for `exist_ok=True` to avoid this situation in similar downstream cases