### PR TITLE
Report unconverged tasks properly

### DIFF
--- a/abipy/flowtk/launcher.py
+++ b/abipy/flowtk/launcher.py
@@ -522,6 +522,7 @@ killjobs_if_errors: yes # "yes" if the scheduler should try to kill all the runn
         for task in flow.unconverged_tasks:
             try:
                 logger.info("Trying to restart task: `%s`" % repr(task))
+                task.manager.qadapter.check_num_launches()  # First check number of launches.
                 fired = task.restart()
                 if fired:
                     self.nlaunch += 1

--- a/abipy/flowtk/qadapters.py
+++ b/abipy/flowtk/qadapters.py
@@ -1116,6 +1116,17 @@ limits:
 
         return qheader + se.get_script_str() + "\n"
 
+    def check_num_launches(self):
+        """
+        Verify that we have not reached the maximum number of launches.
+
+        Raises:
+            `self.MaxNumLaunchesError` if we have already tried to submit the job max_num_launches
+            `self.Error` if generic error
+        """
+        if self.num_launches == self.max_num_launches:
+            raise self.MaxNumLaunchesError("num_launches %s == max_num_launches %s" % (self.num_launches, self.max_num_launches))
+
     def submit_to_queue(self, script_file: str) -> QueueJob:
         """
         Public API: wraps the concrete implementation _submit_to_queue
@@ -1127,8 +1138,7 @@ limits:
         if not os.path.exists(script_file):
             raise self.Error('Cannot find script file located at: {}'.format(script_file))
 
-        if self.num_launches == self.max_num_launches:
-            raise self.MaxNumLaunchesError("num_launches %s == max_num_launches %s" % (self.num_launches, self.max_num_launches))
+        self.check_num_launches()
 
         # Call the concrete implementation.
         s = self._submit_to_queue(script_file)

--- a/abipy/flowtk/tasks.py
+++ b/abipy/flowtk/tasks.py
@@ -2118,7 +2118,7 @@ class Task(Node, metaclass=abc.ABCMeta):
         if not self.output_file.exists:
             #self.history.debug("output_file does not exists")
             if not self.stderr_file.exists and not self.qerr_file.exists:
-                # No output at allThe job is still in the queue.
+                # No output at all. The job is still in the queue.
                 return self.status
 
         # 7) Analyze the files of the resource manager and abinit and execution err (mvs)
@@ -2834,6 +2834,7 @@ class AbinitTask(Task):
         logs = []
         if self.output_file.exists: logs.append(rename_file(self.output_file))
         if self.log_file.exists: logs.append(rename_file(self.log_file))
+        if self.stderr_file.exists: logs.append(rename_file(self.stderr_file))
 
         if logs:
             self.history.info("\n".join(logs))


### PR DESCRIPTION
Check that we reached the maximum number of launches before trying to restart a task. This allows to detect the unconverged status of a task. Otherwise, the output file is renamed and the status is not correctly detected.
