### PR TITLE
Enable use of alchemical pseudoatoms

### DIFF
--- a/abipy/abilab.py
+++ b/abipy/abilab.py
@@ -433,7 +433,8 @@ def abicheck(verbose: int = 0) -> str:
         from packaging.version import parse as parse_version
         from monty.operator import operator_from_str
         op = operator_from_str(op)
-        return op(parse_version(this), parse_version(other))
+        return op(parse_version(this.split('-')[0]),
+                  parse_version(other.split('-')[0]))
 
     from abipy.flowtk import PyFlowScheduler
 

--- a/abipy/abio/inputs.py
+++ b/abipy/abio/inputs.py
@@ -436,7 +436,13 @@ class AbinitInput(AbiAbstractInput, MSONable, Has_Structure):
             pseudos = [os.path.join(pseudo_dir, p) for p in list_strings(pseudos)]
 
         if enforce_znucl is not None:
-            self._pseudos = [Pseudo.from_file(p) for p in pseudos]
+            psps = []
+            for p in pseudos:
+                if isinstance(p, Pseudo):
+                    psps.append(p)
+                else:
+                    psps.append(Pseudo.from_file(p))
+            self._pseudos = psps
         else:
             try:
                 self._pseudos = PseudoTable.as_table(pseudos).get_pseudos_for_structure(self.structure)

--- a/abipy/abio/inputs.py
+++ b/abipy/abio/inputs.py
@@ -435,10 +435,13 @@ class AbinitInput(AbiAbstractInput, MSONable, Has_Structure):
                 raise self.Error(f"Directory `{pseudo_dir}` does not exist")
             pseudos = [os.path.join(pseudo_dir, p) for p in list_strings(pseudos)]
 
-        try:
-            self._pseudos = PseudoTable.as_table(pseudos).get_pseudos_for_structure(self.structure)
-        except ValueError as exc:
-            raise self.Error(str(exc))
+        if enforce_znucl is not None:
+            self._pseudos = [Pseudo.from_file(p) for p in pseudos]
+        else:
+            try:
+                self._pseudos = PseudoTable.as_table(pseudos).get_pseudos_for_structure(self.structure)
+            except ValueError as exc:
+                raise self.Error(str(exc))
 
         if comment is not None: self.set_comment(comment)
 
@@ -490,9 +493,9 @@ class AbinitInput(AbiAbstractInput, MSONable, Has_Structure):
         if len(typat) != len(self.structure):
             raise ValueError("typat contains %d entries while it should be natom: %d" % (len(typat), len(self.structure)))
 
-        ntypat = self.structure.n_elems
-        if len(znucl) != ntypat:
-            raise ValueError("znucl contains %d entries while it should be ntypat: %d" % (len(znucl), ntypat))
+        #ntypat = self.structure.n_elems
+        #if len(znucl) != ntypat:
+        #    raise ValueError("znucl contains %d entries while it should be ntypat: %d" % (len(znucl), ntypat))
 
     def variable_checksum(self) -> str:
         """

--- a/abipy/examples/flows/run_relax.py
+++ b/abipy/examples/flows/run_relax.py
@@ -31,6 +31,7 @@ def make_ion_ioncell_inputs(paral_kgb=0):
         shiftk=[0, 0, 0],
         nshiftk=1,
         chksymbreak=0,
+        chksymtnons=0,
         paral_kgb=paral_kgb,
         iomode=3,
         #prtwf=0,
@@ -84,15 +85,6 @@ def build_flow(options):
 
     relax_work = flowtk.RelaxWork(ion_inp, ioncell_inp)
     flow.register_work(relax_work)
-
-    #bands_work = flowtk.BandStructureWork(scf_input, nscf_input)
-    bands_work = flowtk.Work()
-    deps = {relax_work[-1]: "@structure"}
-    deps = {relax_work[-1]: ["DEN", "@structure"]}  # --> This is not possible because the file ext is changed!
-    #deps = {relax_work[-1]: ["WFK", "@structure"]} # --> This triggers an infamous bug in abinit
-
-    bands_work.register_relax_task(ioncell_inp, deps=deps)
-    flow.register_work(bands_work)
 
     return flow
 


### PR DESCRIPTION
Some changes in AbinitInput object to allow for alchemical pseudoatoms:
- Remove check on the length of znucl
- Accept list of provided pseudos when znucl is specified.

Note that the check on the length of znucl is also present in pymatgen.io.abinit.abiobjects which will have to be updated.
